### PR TITLE
[codex] Add nutrition MVP static site

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,13 @@
 # Fitness Assistant
 
-Static React, TypeScript, and Vite app for the fitness assistant MVP.
+Fitness Assistant is a static React, TypeScript, and Vite app for planning workouts and household nutrition routines. The current MVP focuses on a low-friction nutrition planner that turns a repeatable weekly meal plan into a grocery checklist.
+
+## Current Status
+
+- Draft PR: https://github.com/edwin-lobo/fitness-assistant/pull/14
+- Implemented nutrition issues: `#1` through `#4`
+- Next backlog batch: `#5` through `#8`
+- Deployment target: GitHub Pages
 
 ## Local development
 
@@ -24,24 +31,41 @@ npm run test:e2e
 
 ## Nutrition MVP
 
-The nutrition feature is a household-first planner for lower-friction weekly planning and fewer processed foods.
+The nutrition feature is a household-first planner for lower-friction weekly planning and fewer processed foods. It is intentionally simple: users edit household member preferences, choose meals from repeatable templates, review a generated grocery checklist, and share the result through copy, email, or text.
 
-- `docs/nutrition-mvp-spec.md` defines the MVP scope, out-of-scope items, and week-one success metrics.
+Implemented in this PR:
+
+- Editable household member profiles.
+- Low-choice weekly meal planning.
+- Repeatable meal templates.
+- Grocery checklist generation with duplicate consolidation.
+- Copy, email, and text output for manual grocery-app handoff.
+- Playwright browser coverage for the main nutrition workflow.
+
+Related docs:
+
+- `docs/nutrition-mvp-spec.md` defines scope, out-of-scope items, and success metrics.
 - `docs/nutrition-data-model.md` documents the household, member, meal template, weekly plan, and grocery checklist model.
 - `docs/backlog/nutrition-mvp-backlog.md` links the nutrition backlog issues and priority sequence.
-
-The current app supports editable household member profiles, low-choice weekly meal planning, grocery checklist generation, and copy/email/text output for manual grocery-app handoff.
+- `docs/testing.md` explains local and CI test coverage.
 
 ## Testing
 
-The repo includes Playwright browser tests for the nutrition planner in `tests/e2e/`.
+Run the same checks used by CI:
 
 ```bash
+npm run lint
 npm run build
 npm run test:e2e
 ```
 
 The Playwright config starts `npm run preview` automatically against the built app. The CI workflow in `.github/workflows/ci.yml` runs lint, build, and the Playwright suite for pull requests and pushes to `main`.
+
+If Playwright browsers are missing locally, install Chromium once:
+
+```bash
+npx playwright install chromium
+```
 
 ## Deployment
 
@@ -55,7 +79,10 @@ For a custom domain, set the repository variable `PAGES_CNAME`. The workflow wri
 
 ## Project structure
 
-- `src/components/` contains the page sections and UI blocks.
-- `src/App.tsx` composes the landing page.
+- `src/components/` contains React UI sections and reusable page blocks.
+- `src/data/nutrition.ts` contains the nutrition domain model, seed data, grocery generation, and share-output helpers.
+- `tests/e2e/` contains Playwright browser tests.
+- `.github/workflows/ci.yml` runs PR verification.
+- `.github/workflows/deploy-pages.yml` publishes the static build to GitHub Pages.
 - `vite.config.ts` sets the deploy base path.
 - `eslint.config.js` contains the flat ESLint configuration.

--- a/docs/backlog/nutrition-mvp-backlog.md
+++ b/docs/backlog/nutrition-mvp-backlog.md
@@ -8,6 +8,10 @@ Primary target:
 - Low-decision, planning-accessible defaults
 - Manual grocery-app handoff first
 
+## Current branch status
+
+PR `#14` implements the first four issues. When that PR merges, close `#1` through `#4` and start the second implementation pass.
+
 ## Priority order
 
 1. [#1](https://github.com/edwin-lobo/fitness-assistant/issues/1) `[P0]` Define nutrition MVP scope and one-week success metrics - implemented in `docs/nutrition-mvp-spec.md`
@@ -42,3 +46,12 @@ The remaining issues are intentionally post-MVP:
 - `#10` future multi-household graph design
 - `#11` grocery-app integration research
 - `#12` broader demographic onboarding
+
+## Next recommended work
+
+After PR `#14` merges:
+
+- Close `#1` through `#4`.
+- Keep `#5` through `#8` open as the next product slice.
+- Prioritize `#5` first if sharing/reviewing plans outside the app is the main usage gap.
+- Prioritize `#8` first if repeat weekly use feels more important than new sharing formats.

--- a/docs/nutrition-data-model.md
+++ b/docs/nutrition-data-model.md
@@ -1,5 +1,7 @@
 # Nutrition Data Model
 
+Implementation: `src/data/nutrition.ts`
+
 This model implements the first four nutrition backlog issues:
 
 - `#1` nutrition MVP scope
@@ -9,7 +11,7 @@ This model implements the first four nutrition backlog issues:
 
 ## HouseholdProfile
 
-`HouseholdProfile` is the planning unit. The MVP ships with one default household and two editable members.
+`HouseholdProfile` is the planning unit. The MVP ships with one default household and editable member records.
 
 Fields:
 
@@ -66,4 +68,18 @@ The app builds a grocery checklist from the weekly plan by:
 - sorting items alphabetically inside each category,
 - formatting the result for display and share output.
 
-The implementation lives in `src/data/nutrition.ts`.
+## Helper functions
+
+- `getMealTemplate(id)`: resolves a selected meal template, falling back to the first template if an ID is missing.
+- `getMealTemplatesForSlot(slot)`: returns only templates valid for a meal slot.
+- `buildGroceryChecklist(plan)`: derives grouped grocery sections from a weekly plan.
+- `getLowerProcessedMealPercent(plan)`: calculates the lower-processed meal percentage displayed in the UI.
+- `buildShareOutput(plan, groceryChecklist)`: formats the meal plan and grocery checklist for copy/email/text handoff.
+- `formatQuantity(value)`: renders integer and decimal grocery quantities consistently.
+
+## Current constraints
+
+- Data is currently static and client-side only.
+- Profile edits are local UI state and are not persisted.
+- Grocery quantities are simple aggregate totals, not serving-adjusted by household size yet.
+- Direct grocery-app integrations are intentionally out of scope for the MVP.

--- a/docs/nutrition-mvp-spec.md
+++ b/docs/nutrition-mvp-spec.md
@@ -1,5 +1,7 @@
 # Nutrition MVP Spec
 
+Status: implemented by PR #14 for issues `#1` through `#4`.
+
 ## Goal
 
 Help a shared household decide what to eat this week, generate a grocery checklist, and share the result into an existing grocery workflow.
@@ -34,6 +36,23 @@ Help a shared household decide what to eat this week, generate a grocery checkli
 - The grocery checklist needs little or no cleanup before being added to an external grocery app.
 - At least 70% of planned meals are lower-processed templates.
 - The household can reuse the plan structure the following week with only small edits.
+
+## Implemented behavior
+
+- The app ships with a default shared household and two editable member profiles.
+- A seven-day plan is prefilled from repeatable meal templates.
+- Users can change breakfast, lunch, and dinner selections by day.
+- The grocery checklist updates from the selected meals.
+- The share output updates with the meal plan and checklist.
+- Users can copy the share output or open email/text handoff links.
+
+## Review checklist
+
+- The nutrition section renders on desktop and mobile.
+- Editing member profile fields does not break the generated plan.
+- Changing a meal updates the grocery checklist and share output.
+- The copy handoff action reports success or a browser-blocked fallback message.
+- The docs use generic shared-household language and avoid personal household details.
 
 ## Core concepts
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,0 +1,53 @@
+# Testing
+
+The repo uses three checks for the current MVP:
+
+- ESLint for static code checks.
+- Vite production build for compile and bundling checks.
+- Playwright for browser-level nutrition planner workflows.
+
+## Local checks
+
+Run all checks before marking the PR ready:
+
+```bash
+npm run lint
+npm run build
+npm run test:e2e
+```
+
+The Playwright config starts `npm run preview` automatically against the built app.
+
+If the Chromium browser is not installed locally, run:
+
+```bash
+npx playwright install chromium
+```
+
+## Browser coverage
+
+The Playwright suite in `tests/e2e/nutrition-planner.spec.ts` covers:
+
+- Rendering the household meal planner and grocery checklist.
+- Editing a member profile.
+- Changing a weekly meal selection.
+- Verifying the grocery checklist updates.
+- Verifying share output stays in sync with the plan.
+- Verifying the copy handoff flow.
+
+## CI
+
+`.github/workflows/ci.yml` runs on pull requests and pushes to `main`.
+
+The workflow:
+
+- installs dependencies with `npm ci`,
+- installs the Chromium Playwright browser,
+- runs `npm run lint`,
+- runs `npm run build`,
+- runs `npm run test:e2e`,
+- uploads the Playwright report artifact when available.
+
+## Known local environment notes
+
+Some sandboxed environments block localhost ports unless explicitly allowed. If Playwright fails to start the preview server with a listen permission error, rerun the command in an environment that can bind to `127.0.0.1`.


### PR DESCRIPTION
## Summary
- Adds the Vite/React static Fitness Assistant app with GitHub Pages deployment support.
- Implements the first four nutrition MVP issues: scope docs, household/member model, low-choice weekly meal planner, and grocery checklist generation.
- Adds Playwright e2e coverage, CI verification, and refreshed documentation for testing, deployment, and backlog status.

## Validation
- npm run lint
- npm run build
- npm run test:e2e

## Notes
- Issues #1 through #4 should be closed when this PR merges.
- This replaces the earlier closed draft PR and includes the latest documentation update commit.