### PR TITLE
Nutrition MVP static site + session handoff

### DIFF
--- a/docs/prompts/codex/startup-prompt.md
+++ b/docs/prompts/codex/startup-prompt.md
@@ -1,0 +1,89 @@
+# Session Handoff
+
+Current plan snapshot:
+- Keep the app frontend-first and polish the live nutrition workflow.
+- Finish the remaining nutrition MVP backlog items before widening scope.
+- Use the GitHub Pages deployment path as the default release target.
+
+Read next:
+- `docs/session-handoff.md`
+- `docs/nutrition-mvp-spec.md`
+- `docs/nutrition-data-model.md`
+- `docs/backlog/nutrition-mvp-backlog.md`
+
+# Goal
+I want to design a modular, configurable prompt system for my workout-tracking and fitness-automation app.
+The system should support **multiple output formats** (e.g., Excel CSV rows, Google Sheets formulas, JSON API payloads), and I want my prompts to be reusable across different LLMs and providers.
+
+# Current App Shape
+- Runtime: Python
+- I will orchestrate prompts inside Python, using a clean directory hierarchy (prompts/, schemas/, configs/, etc.)
+- I will integrate with multiple LLM providers over time:
+  - OpenAI for the next month
+  - Later: Anthropic, Azure OpenAI, Gemini
+- Workloads include:
+  - Workout plan generation
+  - Load progression / progressive overload calculation
+  - CSV/Excel outputs for Sheets
+  - JSON API outputs for my future application
+  - Possibly web UI rendering later
+- I also want to implement PromptFlow and later compare it to Dotprompt for managing prompts, variants, and evaluations.
+
+# Desired Output Formats
+I want the model to conditionally switch outputs depending on a parameter:
+
+## Format A: "excel_sheet"
+- Must follow CSV format.
+- First row is the header.
+- Rows must match a schema.
+- Formulas (Google Sheets syntax) must be placed only in relevant columns.
+- No narrative text.
+
+## Format B: "web_api"
+- Must return JSON matching a JSON Schema.
+- Keys must follow snake_case.
+- No extra text or Markdown.
+
+## Format C: "markdown_doc"
+- Full markdown file (formatted for a repo, app docs, or README.md).
+- Can include headings, tables, bullet lists, and diagrams.
+
+## Format D: “analysis_only”
+- Only reasoning / explanation (no data structures).
+- Useful for debugging.
+
+I want a single **base prompt** that allows switching among these formats using an input variable, e.g.:
+
+`output_format: "excel_sheet"`
+
+# Constraints
+- Prompts must be versionable, modular, readable.
+- Prompts should live as `.prompt.md` or `.md` files under `app/prompts/`.
+- JSON Schemas should live in `app/schemas/`.
+- Configurable variables should come from config YAML/JSON files (e.g., week counts, set ranges, RPE targets).
+- Output must not mix formats.
+- Must work across providers (OpenAI, Anthropic, Azure).
+
+# Ask
+1. Design a directory structure for:
+   - prompts/
+   - schemas/
+   - configs/
+   - optional promptflow/ folder
+2. Generate the following files:
+   - `prompts/workout/base.prompt.md`
+   - `prompts/workout/excel_sheet.prompt.md`
+   - `prompts/workout/web_api.prompt.md`
+   - `schemas/workout_plan.schema.json`
+   - `schemas/workout_set.schema.json`
+3. Show me a minimal PromptFlow pipeline for orchestrating:
+   - python code → load config → render base prompt → call LLM → validate output.
+4. Explain how this setup compares to Google Dotprompt (advantages, disadvantages).
+5. Show me how to add parameters like:
+   - `output_format`
+   - `units`
+   - `block_number`
+   - `week_range`
+
+# Optional (if useful)
+Use the current workout program we built (8-week, 2-block structure) as the reference workout logic.

--- a/docs/session-handoff.md
+++ b/docs/session-handoff.md
@@ -1,0 +1,16 @@
+# Session Handoff
+
+Current state:
+- Live frontend deployed at `https://edwin-lobo.github.io/fitness-assistant/`.
+- The MVP centers on the household nutrition planner and grocery checklist workflow.
+- Existing docs already cover the nutrition spec, data model, backlog, and testing.
+
+Current plan:
+- Keep the app frontend-first and tighten the overall product polish.
+- Finish the remaining nutrition MVP backlog items before adding broader feature scope.
+- Keep the GitHub Pages deploy path stable and rerun lint/build/E2E after UI changes.
+
+Suggested next session starting point:
+1. Read `docs/nutrition-mvp-spec.md`, `docs/nutrition-data-model.md`, and `docs/backlog/nutrition-mvp-backlog.md`.
+2. Review `src/components/` and `src/data/nutrition.ts` for the current UI/data flow.
+3. Make the next MVP-facing improvement, then verify with `npm run lint`, `npm run build`, and `npm run test:e2e`.

--- a/index.html
+++ b/index.html
@@ -2,9 +2,9 @@
 <html lang="en" class="scroll-smooth">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <link rel="icon" type="image/svg+xml" href="./favicon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Fitness Assistant | LensKeep</title>
+    <title>Fitness Assistant</title>
   </head>
   <body class="bg-slate-50 text-slate-900">
     <div id="root"></div>

--- a/public/favicon.svg
+++ b/public/favicon.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-label="Fitness Assistant">
+  <rect width="64" height="64" rx="16" fill="#12312b"/>
+  <path d="M18 40c0-9.4 7.6-17 17-17h11v11c0 9.4-7.6 17-17 17H18V40z" fill="#d6f3b3"/>
+  <path d="M18 40c0-9.4 7.6-17 17-17h3c-1.8 8.5-8.5 15.2-17 17h-3z" fill="#79b791"/>
+  <circle cx="24" cy="20" r="6" fill="#f4a261"/>
+</svg>


### PR DESCRIPTION
## Summary

- Adds the nutrition MVP static site (React + Vite + Tailwind, GitHub Pages deploy)
- Updates README, docs (spec, data model, backlog, testing guide)
- Adds session handoff and Codex startup prompt for agent continuity

## Test plan

- [ ] CI passes (lint + build + Playwright e2e)
- [ ] GitHub Pages deploy succeeds after merge
- [ ] Nutrition planner renders at the deployed URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)