### PR TITLE
Implement nutrition planning backlog slice

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,10 @@ Fitness Assistant is a static React, TypeScript, and Vite app for planning worko
 
 ## Current Status
 
-- Nutrition MVP branch includes issues: `#1` through `#8`
-- Next backlog batch: `#9` through `#12`
+- Live site: https://edwin-lobo.github.io/fitness-assistant/
+- Merged MVP foundation: issues `#1` through `#4`
+- Open review: PR `#17` implements issues `#5` through `#8`
+- Next backlog batch after PR `#17`: issues `#9` through `#12`
 - Deployment target: GitHub Pages
 
 ## Local development
@@ -32,7 +34,7 @@ npm run test:e2e
 
 The nutrition feature is a household-first planner for lower-friction weekly planning and fewer processed foods. It is intentionally simple: users edit household member preferences, choose meals from repeatable templates, review a generated grocery checklist, and share the result through copy, email, or text.
 
-Implemented in this PR:
+Implemented across the nutrition MVP branch:
 
 - Editable household member profiles.
 - Low-choice weekly meal planning.
@@ -48,6 +50,7 @@ Implemented in this PR:
 Related docs:
 
 - `docs/nutrition-mvp-spec.md` defines scope, out-of-scope items, and success metrics.
+- `docs/nutrition-workflow.md` explains the current user workflow and manual grocery-app handoff.
 - `docs/nutrition-data-model.md` documents the household, member, meal template, weekly plan, and grocery checklist model.
 - `docs/backlog/nutrition-mvp-backlog.md` links the nutrition backlog issues and priority sequence.
 - `docs/testing.md` explains local and CI test coverage.

--- a/README.md
+++ b/README.md
@@ -4,9 +4,8 @@ Fitness Assistant is a static React, TypeScript, and Vite app for planning worko
 
 ## Current Status
 
-- Draft PR: https://github.com/edwin-lobo/fitness-assistant/pull/14
-- Implemented nutrition issues: `#1` through `#4`
-- Next backlog batch: `#5` through `#8`
+- Nutrition MVP branch includes issues: `#1` through `#8`
+- Next backlog batch: `#9` through `#12`
 - Deployment target: GitHub Pages
 
 ## Local development
@@ -39,7 +38,11 @@ Implemented in this PR:
 - Low-choice weekly meal planning.
 - Repeatable meal templates.
 - Grocery checklist generation with duplicate consolidation.
+- Reusable week templates for balanced, batch-cook, and low-decision planning.
+- Low-friction one-click repeat and lower-processed swap actions.
 - Copy, email, and text output for manual grocery-app handoff.
+- Share formats for full plans, grocery-only handoff, and reusable meal templates.
+- Processed-food reduction guidance tied to planned meals.
 - Playwright browser coverage for the main nutrition workflow.
 
 Related docs:

--- a/docs/backlog/nutrition-mvp-backlog.md
+++ b/docs/backlog/nutrition-mvp-backlog.md
@@ -10,7 +10,7 @@ Primary target:
 
 ## Current branch status
 
-Issues `#1` through `#4` are closed. The current branch implements the second MVP pass for `#5` through `#8`.
+Issues `#1` through `#4` are closed. PR `#17` implements the second MVP pass for `#5` through `#8`; those issues should close when PR `#17` merges.
 
 ## Priority order
 
@@ -29,7 +29,7 @@ Issues `#1` through `#4` are closed. The current branch implements the second MV
 
 ## MVP delivery sequence
 
-The first implementation pass should complete:
+The first implementation pass is complete:
 - `#1` MVP definition
 - `#2` household/member profile model
 - `#3` weekly meal planning system
@@ -40,6 +40,8 @@ The second implementation pass completes:
 - `#6` low-friction planning
 - `#7` processed-food reduction guidance
 - `#8` reusable meal templates
+
+Status: implemented in PR `#17`, pending merge.
 
 The remaining issues are intentionally post-MVP:
 - `#9` richer planner interactions

--- a/docs/backlog/nutrition-mvp-backlog.md
+++ b/docs/backlog/nutrition-mvp-backlog.md
@@ -10,7 +10,7 @@ Primary target:
 
 ## Current branch status
 
-PR `#14` implements the first four issues. When that PR merges, close `#1` through `#4` and start the second implementation pass.
+Issues `#1` through `#4` are closed. The current branch implements the second MVP pass for `#5` through `#8`.
 
 ## Priority order
 
@@ -18,10 +18,10 @@ PR `#14` implements the first four issues. When that PR merges, close `#1` throu
 2. [#2](https://github.com/edwin-lobo/fitness-assistant/issues/2) `[P0]` Design household and member profile model for nutrition planning - implemented in `docs/nutrition-data-model.md` and `src/data/nutrition.ts`
 3. [#3](https://github.com/edwin-lobo/fitness-assistant/issues/3) `[P0]` Build a low-choice weekly meal planning system - implemented in `src/components/NutritionPlanner.tsx`
 4. [#4](https://github.com/edwin-lobo/fitness-assistant/issues/4) `[P0]` Generate a grocery checklist from the weekly meal plan - implemented in `src/data/nutrition.ts`
-5. [#5](https://github.com/edwin-lobo/fitness-assistant/issues/5) `[P1]` Add share outputs for meal plan and grocery list
-6. [#6](https://github.com/edwin-lobo/fitness-assistant/issues/6) `[P1]` Make the nutrition planning flow low-friction and planning-accessible
-7. [#7](https://github.com/edwin-lobo/fitness-assistant/issues/7) `[P1]` Add processed-food reduction guidance and practical swap logic
-8. [#8](https://github.com/edwin-lobo/fitness-assistant/issues/8) `[P1]` Support weekly habit formation with reusable meal templates
+5. [#5](https://github.com/edwin-lobo/fitness-assistant/issues/5) `[P1]` Add share outputs for meal plan and grocery list - implemented in `src/components/NutritionPlanner.tsx` and `src/data/nutrition.ts`
+6. [#6](https://github.com/edwin-lobo/fitness-assistant/issues/6) `[P1]` Make the nutrition planning flow low-friction and planning-accessible - implemented with one-click repeat and swap actions
+7. [#7](https://github.com/edwin-lobo/fitness-assistant/issues/7) `[P1]` Add processed-food reduction guidance and practical swap logic - implemented with meal swap tips and lower-processed dinner swaps
+8. [#8](https://github.com/edwin-lobo/fitness-assistant/issues/8) `[P1]` Support weekly habit formation with reusable meal templates - implemented with reusable week templates
 9. [#9](https://github.com/edwin-lobo/fitness-assistant/issues/9) `[P2]` Add richer weekly planner interactions after the repeatable flow works
 10. [#10](https://github.com/edwin-lobo/fitness-assistant/issues/10) `[P2]` Design future multi-household and member graph model
 11. [#11](https://github.com/edwin-lobo/fitness-assistant/issues/11) `[P3]` Research grocery-app integration feasibility
@@ -35,7 +35,7 @@ The first implementation pass should complete:
 - `#3` weekly meal planning system
 - `#4` grocery checklist generation
 
-The second pass should complete:
+The second implementation pass completes:
 - `#5` share outputs
 - `#6` low-friction planning
 - `#7` processed-food reduction guidance
@@ -49,9 +49,9 @@ The remaining issues are intentionally post-MVP:
 
 ## Next recommended work
 
-After PR `#14` merges:
+After the second MVP pass merges:
 
-- Close `#1` through `#4`.
-- Keep `#5` through `#8` open as the next product slice.
-- Prioritize `#5` first if sharing/reviewing plans outside the app is the main usage gap.
-- Prioritize `#8` first if repeat weekly use feels more important than new sharing formats.
+- Close `#5` through `#8`.
+- Keep `#9` through `#12` open as the post-MVP backlog.
+- Prioritize `#9` first if the planner needs richer interactive editing.
+- Prioritize `#11` first if grocery-app handoff becomes the largest workflow gap.

--- a/docs/nutrition-data-model.md
+++ b/docs/nutrition-data-model.md
@@ -2,12 +2,16 @@
 
 Implementation: `src/data/nutrition.ts`
 
-This model implements the first four nutrition backlog issues:
+This model implements the first eight nutrition backlog issues:
 
 - `#1` nutrition MVP scope
 - `#2` household and member profile model
 - `#3` low-choice weekly meal planning
 - `#4` grocery checklist generation
+- `#5` share outputs for meal plans and groceries
+- `#6` low-friction planning actions
+- `#7` processed-food reduction guidance
+- `#8` reusable meal templates
 
 ## HouseholdProfile
 
@@ -45,7 +49,20 @@ Fields:
 - `processedLevel`: `low` or `medium`.
 - `repeatFriendly`: whether the meal is suitable for repeated use in the same week.
 - `why`: short planning rationale.
+- `swapTip`: practical guidance for keeping the meal less processed or improving a medium-processed fallback.
 - `ingredients`: grocery inputs for checklist generation.
+
+## WeekTemplate
+
+`WeekTemplate` is a reusable seven-day plan preset for different planning-energy levels.
+
+Fields:
+
+- `id`: stable template identifier.
+- `name`: display name.
+- `description`: short explanation of the pattern.
+- `bestFor`: concise use case label.
+- `plan`: a complete `DayPlan[]` preset.
 
 ## DayPlan
 
@@ -73,7 +90,16 @@ The app builds a grocery checklist from the weekly plan by:
 - `getMealTemplate(id)`: resolves a selected meal template, falling back to the first template if an ID is missing.
 - `getMealTemplatesForSlot(slot)`: returns only templates valid for a meal slot.
 - `buildGroceryChecklist(plan)`: derives grouped grocery sections from a weekly plan.
+- `buildGroceryAppOutput(groceryChecklist)`: formats a plain line-by-line list for external grocery apps.
+- `buildGroceryOutput(groceryChecklist)`: formats a categorized grocery list.
+- `buildMealTemplateOutput(plan)`: formats the current week as a reusable template.
+- `buildRepeatMealPlan(mealId, slot, currentPlan)`: repeats one selected meal across a slot for the week.
+- `buildLowerProcessedPlan(currentPlan)`: swaps medium-processed dinners to lower-processed defaults.
+- `buildTemplatePlan(id)`: creates a cloned plan from a reusable week template.
 - `getLowerProcessedMealPercent(plan)`: calculates the lower-processed meal percentage displayed in the UI.
+- `getPlanningSummary(plan)`: returns quick counts for decision load, repeat-friendly meals, and fast starts.
+- `getProcessedSwapTips(plan)`: returns swap guidance for planned medium-processed meals.
+- `getWeekTemplateMatch(plan)`: identifies whether the current plan matches a reusable preset.
 - `buildShareOutput(plan, groceryChecklist)`: formats the meal plan and grocery checklist for copy/email/text handoff.
 - `formatQuantity(value)`: renders integer and decimal grocery quantities consistently.
 

--- a/docs/nutrition-mvp-spec.md
+++ b/docs/nutrition-mvp-spec.md
@@ -1,6 +1,6 @@
 # Nutrition MVP Spec
 
-Status: implemented by PR #14 for issues `#1` through `#4`.
+Status: implemented for issues `#1` through `#8`.
 
 ## Goal
 
@@ -17,6 +17,8 @@ Help a shared household decide what to eat this week, generate a grocery checkli
 - Household-first planning with editable member profiles.
 - Low-choice weekly meal planning.
 - Repeatable meal templates.
+- Reusable week templates for different planning-energy levels.
+- Low-friction repeat and swap actions for hard planning weeks.
 - Grocery checklist generated from the selected weekly plan.
 - Manual grocery-app handoff through copy, email, or text output.
 - Practical less-processed-food guidance through template choices and swap-friendly language.
@@ -42,15 +44,22 @@ Help a shared household decide what to eat this week, generate a grocery checkli
 - The app ships with a default shared household and two editable member profiles.
 - A seven-day plan is prefilled from repeatable meal templates.
 - Users can change breakfast, lunch, and dinner selections by day.
+- Users can apply reusable week templates instead of starting from a blank plan.
+- Users can repeat a meal across the week with one action.
+- Users can apply lower-processed dinner swaps when the plan includes medium-processed meals.
 - The grocery checklist updates from the selected meals.
 - The share output updates with the meal plan and checklist.
+- Users can choose between full-plan, grocery-only, and reusable-template share formats.
 - Users can copy the share output or open email/text handoff links.
+- Users can review practical swap tips for planned medium-processed meals.
 
 ## Review checklist
 
 - The nutrition section renders on desktop and mobile.
 - Editing member profile fields does not break the generated plan.
 - Changing a meal updates the grocery checklist and share output.
+- Applying a week template changes the plan and preserves grocery generation.
+- Applying lower-processed swaps updates the low-processed percentage and guidance.
 - The copy handoff action reports success or a browser-blocked fallback message.
 - The docs use generic shared-household language and avoid personal household details.
 

--- a/docs/nutrition-mvp-spec.md
+++ b/docs/nutrition-mvp-spec.md
@@ -1,6 +1,6 @@
 # Nutrition MVP Spec
 
-Status: implemented for issues `#1` through `#8`.
+Status: issues `#1` through `#4` are merged; issues `#5` through `#8` are implemented in PR `#17` pending merge.
 
 ## Goal
 
@@ -71,3 +71,5 @@ Help a shared household decide what to eat this week, generate a grocery checkli
 - `WeeklyMealPlan`: selected templates across days and meal slots.
 - `GroceryChecklist`: consolidated shopping output derived from the weekly plan.
 - `ShareOutput`: text formats suitable for copy, email, text, and future web sharing.
+
+See `docs/nutrition-workflow.md` for the user-facing workflow and handoff behavior.

--- a/docs/nutrition-workflow.md
+++ b/docs/nutrition-workflow.md
@@ -1,0 +1,49 @@
+# Nutrition Workflow
+
+This document describes the current nutrition planner flow for product review and manual testing.
+
+## User path
+
+1. Review the household profile and edit member names, preferences, avoids, convenience needs, or repeat tolerance.
+2. Start from the prefilled weekly plan or apply a reusable week template.
+3. Adjust breakfast, lunch, or dinner selections for individual days as needed.
+4. Use low-friction actions when planning bandwidth is low:
+   - repeat the default breakfast, lunch, or dinner across the week,
+   - apply lower-processed dinner swaps.
+5. Review the grocery checklist generated from the selected meals.
+6. Choose a share format:
+   - full plan,
+   - groceries only,
+   - reusable meal template.
+7. Copy the selected output, email it, text it, or paste the grocery-only output into an external grocery list app.
+
+## Reusable Week Templates
+
+- Balanced repeat week: general default for starting from scratch.
+- Batch-cook week: repeats lunches and dinners in pairs to reduce weekday prep.
+- Low-decision week: repeats breakfast and lunch heavily for high-friction planning weeks.
+
+## Processed-Food Guidance
+
+The planner treats lower-processed eating as a practical direction, not a perfection rule.
+
+- Meal templates include a `processedLevel` and a practical `swapTip`.
+- The planner shows the percentage of lower-processed meals in the current week.
+- If medium-processed meals are planned, the guidance section explains how to make the fallback less processed.
+- The lower-processed dinner action replaces medium-processed dinners with a lower-processed default.
+
+## Manual Grocery-App Handoff
+
+Direct grocery-app integration is intentionally out of scope for the MVP. The current handoff is copy-first:
+
+- Full plan: includes the weekly meal plan plus categorized groceries.
+- Groceries only: plain line-by-line output designed for pasting into an external grocery app.
+- Categorized groceries: grouped checklist for review or sharing.
+
+## Review Checklist
+
+- Applying each week template updates the weekly plan and grocery checklist.
+- Changing one meal updates the grocery checklist and share output.
+- Grocery-only output excludes the meal plan and remains easy to paste elsewhere.
+- Lower-processed swaps update the lower-processed percentage and guidance.
+- Copy actions show either success text or a browser-blocked fallback.

--- a/docs/session-handoff.md
+++ b/docs/session-handoff.md
@@ -2,12 +2,12 @@
 
 Current state:
 - Live frontend deployed at `https://edwin-lobo.github.io/fitness-assistant/`.
-- The MVP centers on the household nutrition planner and grocery checklist workflow.
+- The MVP centers on the household nutrition planner, reusable week templates, grocery checklist workflow, and manual share handoff.
 - Existing docs already cover the nutrition spec, data model, backlog, and testing.
 
 Current plan:
 - Keep the app frontend-first and tighten the overall product polish.
-- Finish the remaining nutrition MVP backlog items before adding broader feature scope.
+- Merge the `#5` through `#8` implementation pass, then move to post-MVP issues `#9` through `#12`.
 - Keep the GitHub Pages deploy path stable and rerun lint/build/E2E after UI changes.
 
 Suggested next session starting point:

--- a/docs/session-handoff.md
+++ b/docs/session-handoff.md
@@ -2,7 +2,8 @@
 
 Current state:
 - Live frontend deployed at `https://edwin-lobo.github.io/fitness-assistant/`.
-- The MVP centers on the household nutrition planner, reusable week templates, grocery checklist workflow, and manual share handoff.
+- PR `#17` is open with the `#5` through `#8` implementation pass.
+- The nutrition MVP centers on the household planner, reusable week templates, grocery checklist workflow, and manual share handoff.
 - Existing docs already cover the nutrition spec, data model, backlog, and testing.
 
 Current plan:
@@ -11,6 +12,6 @@ Current plan:
 - Keep the GitHub Pages deploy path stable and rerun lint/build/E2E after UI changes.
 
 Suggested next session starting point:
-1. Read `docs/nutrition-mvp-spec.md`, `docs/nutrition-data-model.md`, and `docs/backlog/nutrition-mvp-backlog.md`.
+1. Read `docs/nutrition-mvp-spec.md`, `docs/nutrition-workflow.md`, `docs/nutrition-data-model.md`, and `docs/backlog/nutrition-mvp-backlog.md`.
 2. Review `src/components/` and `src/data/nutrition.ts` for the current UI/data flow.
 3. Make the next MVP-facing improvement, then verify with `npm run lint`, `npm run build`, and `npm run test:e2e`.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -33,6 +33,9 @@ The Playwright suite in `tests/e2e/nutrition-planner.spec.ts` covers:
 - Changing a weekly meal selection.
 - Verifying the grocery checklist updates.
 - Verifying share output stays in sync with the plan.
+- Applying reusable week templates.
+- Applying low-friction repeat and lower-processed swap actions.
+- Switching between full-plan, grocery-only, and reusable-template share formats.
 - Verifying the copy handoff flow.
 
 ## CI

--- a/src/components/NutritionPlanner.tsx
+++ b/src/components/NutritionPlanner.tsx
@@ -1,30 +1,58 @@
 import React, { useMemo, useState } from 'react';
 import {
+  buildGroceryAppOutput,
   buildGroceryChecklist,
+  buildGroceryOutput,
+  buildLowerProcessedPlan,
+  buildMealTemplateOutput,
+  buildRepeatMealPlan,
   buildShareOutput,
+  buildTemplatePlan,
   defaultHousehold,
   defaultWeeklyPlan,
   formatQuantity,
   getLowerProcessedMealPercent,
   getMealTemplatesForSlot,
+  getPlanningSummary,
+  getProcessedSwapTips,
+  getWeekTemplateMatch,
   mealTemplates,
   type DayPlan,
   type MealSlot,
   type MemberProfile,
   type PreferenceLevel,
+  weekTemplates,
 } from '../data/nutrition';
 
 const preferenceLevels: PreferenceLevel[] = ['low', 'medium', 'high'];
 const mealSlots: MealSlot[] = ['breakfast', 'lunch', 'dinner'];
+const shareModes = ['Full plan', 'Groceries only', 'Meal template'] as const;
+
+type ShareMode = (typeof shareModes)[number];
 
 const NutritionPlanner: React.FC = () => {
   const [members, setMembers] = useState<MemberProfile[]>(defaultHousehold.members);
   const [plan, setPlan] = useState<DayPlan[]>(defaultWeeklyPlan);
   const [shareStatus, setShareStatus] = useState('Ready to share');
+  const [shareMode, setShareMode] = useState<ShareMode>('Full plan');
 
   const groceryChecklist = useMemo(() => buildGroceryChecklist(plan), [plan]);
-  const shareText = useMemo(() => buildShareOutput(plan, groceryChecklist), [groceryChecklist, plan]);
+  const shareText = useMemo(() => {
+    if (shareMode === 'Groceries only') {
+      return buildGroceryAppOutput(groceryChecklist);
+    }
+
+    if (shareMode === 'Meal template') {
+      return buildMealTemplateOutput(plan);
+    }
+
+    return buildShareOutput(plan, groceryChecklist);
+  }, [groceryChecklist, plan, shareMode]);
+  const groceryText = useMemo(() => buildGroceryOutput(groceryChecklist), [groceryChecklist]);
   const lowerProcessedPercent = useMemo(() => getLowerProcessedMealPercent(plan), [plan]);
+  const swapTips = useMemo(() => getProcessedSwapTips(plan), [plan]);
+  const planningSummary = useMemo(() => getPlanningSummary(plan), [plan]);
+  const matchedTemplate = useMemo(() => getWeekTemplateMatch(plan), [plan]);
 
   const updateMember = <K extends keyof MemberProfile>(id: string, field: K, value: MemberProfile[K]) => {
     setMembers((current) => current.map((member) => (member.id === id ? { ...member, [field]: value } : member)));
@@ -34,18 +62,33 @@ const NutritionPlanner: React.FC = () => {
     setPlan((current) => current.map((item) => (item.day === day ? { ...item, [slot]: mealId } : item)));
   };
 
-  const copyShareText = async () => {
+  const copyText = async (value: string, successMessage: string) => {
     try {
-      await navigator.clipboard.writeText(shareText);
-      setShareStatus('Copied plan and grocery list');
+      await navigator.clipboard.writeText(value);
+      setShareStatus(successMessage);
     } catch {
       setShareStatus('Copy blocked by browser; use the text box below');
     }
   };
 
   const repeatSimpleWeek = () => {
-    setPlan(defaultWeeklyPlan);
+    setPlan(buildTemplatePlan('balanced-repeat'));
     setShareStatus('Simple repeatable week restored');
+  };
+
+  const applyTemplate = (templateId: string) => {
+    setPlan(buildTemplatePlan(templateId));
+    setShareStatus('Reusable week template applied');
+  };
+
+  const repeatMealAcrossWeek = (slot: MealSlot, mealId: string) => {
+    setPlan((current) => buildRepeatMealPlan(mealId, slot, current));
+    setShareStatus(`${slot} repeated across the week`);
+  };
+
+  const lowerProcessedDinners = () => {
+    setPlan((current) => buildLowerProcessedPlan(current));
+    setShareStatus('Lower-processed dinner swaps applied');
   };
 
   return (
@@ -141,27 +184,52 @@ const NutritionPlanner: React.FC = () => {
 
           <article className="card p-6">
             <h3 className="text-lg font-semibold text-slate-900">Share output</h3>
-            <p className="mt-1 text-sm text-slate-600">{shareStatus}</p>
-            <div className="mt-4 flex flex-wrap gap-3">
-              <button
-                type="button"
-                onClick={copyShareText}
-                className="rounded-md bg-primary-600 px-4 py-2 text-sm font-semibold text-white hover:bg-primary-700"
-              >
-                Copy grocery handoff
-              </button>
-              <a
-                className="rounded-md border border-slate-200 px-4 py-2 text-sm font-semibold text-slate-700 hover:border-primary-200 hover:text-primary-700"
-                href={`mailto:?subject=${encodeURIComponent('Weekly meal plan')}&body=${encodeURIComponent(shareText)}`}
-              >
-                Email
-              </a>
-              <a
-                className="rounded-md border border-slate-200 px-4 py-2 text-sm font-semibold text-slate-700 hover:border-primary-200 hover:text-primary-700"
-                href={`sms:?&body=${encodeURIComponent(shareText)}`}
-              >
-                Text
-              </a>
+            <p className="mt-1 text-sm text-slate-600">
+              {shareStatus}. Choose the smallest useful output before sending it elsewhere.
+            </p>
+            <div className="mt-4 grid gap-3">
+              <label className="text-sm font-semibold text-slate-700">
+                Output format
+                <select
+                  className="mt-1 w-full rounded-md border border-slate-200 px-3 py-2"
+                  value={shareMode}
+                  onChange={(event) => setShareMode(event.target.value as ShareMode)}
+                >
+                  {shareModes.map((mode) => (
+                    <option key={mode} value={mode}>
+                      {mode}
+                    </option>
+                  ))}
+                </select>
+              </label>
+              <div className="flex flex-wrap gap-3">
+                <button
+                  type="button"
+                  onClick={() => copyText(shareText, `Copied ${shareMode.toLowerCase()}`)}
+                  className="rounded-md bg-primary-600 px-4 py-2 text-sm font-semibold text-white hover:bg-primary-700"
+                >
+                  Copy selected output
+                </button>
+                <button
+                  type="button"
+                  onClick={() => copyText(groceryText, 'Copied categorized grocery list')}
+                  className="rounded-md border border-slate-200 px-4 py-2 text-sm font-semibold text-slate-700 hover:border-primary-200 hover:text-primary-700"
+                >
+                  Copy categorized groceries
+                </button>
+                <a
+                  className="rounded-md border border-slate-200 px-4 py-2 text-sm font-semibold text-slate-700 hover:border-primary-200 hover:text-primary-700"
+                  href={`mailto:?subject=${encodeURIComponent('Weekly meal plan')}&body=${encodeURIComponent(shareText)}`}
+                >
+                  Email
+                </a>
+                <a
+                  className="rounded-md border border-slate-200 px-4 py-2 text-sm font-semibold text-slate-700 hover:border-primary-200 hover:text-primary-700"
+                  href={`sms:?&body=${encodeURIComponent(shareText)}`}
+                >
+                  Text
+                </a>
+              </div>
             </div>
             <textarea
               className="mt-4 h-48 w-full rounded-md border border-slate-200 bg-slate-50 p-3 text-xs leading-relaxed text-slate-700"
@@ -176,7 +244,10 @@ const NutritionPlanner: React.FC = () => {
             <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
               <div>
                 <h3 className="text-lg font-semibold text-slate-900">Weekly meal plan</h3>
-                <p className="mt-1 text-sm text-slate-600">Defaults repeat meals to lower planning effort.</p>
+                <p className="mt-1 text-sm text-slate-600">
+                  Defaults repeat meals to lower planning effort.
+                  {matchedTemplate ? ` Current template: ${matchedTemplate.name}.` : ' Custom week.'}
+                </p>
               </div>
               <button
                 type="button"
@@ -185,6 +256,36 @@ const NutritionPlanner: React.FC = () => {
               >
                 Reset to simple week
               </button>
+            </div>
+
+            <div className="mt-5 grid gap-3 md:grid-cols-3">
+              {weekTemplates.map((template) => (
+                <button
+                  key={template.id}
+                  type="button"
+                  onClick={() => applyTemplate(template.id)}
+                  className="rounded-xl border border-slate-200 bg-slate-50 p-4 text-left hover:border-primary-200 hover:bg-primary-50"
+                >
+                  <span className="text-xs font-semibold uppercase tracking-wide text-primary-700">{template.bestFor}</span>
+                  <span className="mt-1 block text-sm font-semibold text-slate-900">{template.name}</span>
+                  <span className="mt-1 block text-xs leading-relaxed text-slate-600">{template.description}</span>
+                </button>
+              ))}
+            </div>
+
+            <div className="mt-5 grid gap-3 rounded-2xl border border-emerald-100 bg-emerald-50 p-4 text-sm text-emerald-950 md:grid-cols-3">
+              <div>
+                <p className="text-xs font-semibold uppercase tracking-wide text-emerald-700">Decision load</p>
+                <p className="mt-1 font-semibold">{planningSummary.uniqueMeals} unique meals this week</p>
+              </div>
+              <div>
+                <p className="text-xs font-semibold uppercase tracking-wide text-emerald-700">Repeat support</p>
+                <p className="mt-1 font-semibold">{planningSummary.repeatFriendlyMeals} repeat-friendly slots</p>
+              </div>
+              <div>
+                <p className="text-xs font-semibold uppercase tracking-wide text-emerald-700">Fast starts</p>
+                <p className="mt-1 font-semibold">{planningSummary.tenMinuteMeals} ten-minute meals</p>
+              </div>
             </div>
 
             <div className="mt-5 overflow-x-auto">
@@ -223,6 +324,43 @@ const NutritionPlanner: React.FC = () => {
             </div>
           </article>
 
+          <article className="card p-6">
+            <div className="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
+              <div>
+                <h3 className="text-lg font-semibold text-slate-900">Low-friction planning actions</h3>
+                <p className="mt-1 text-sm text-slate-600">
+                  Use one-click changes when planning bandwidth is low instead of editing every day.
+                </p>
+              </div>
+              <button
+                type="button"
+                onClick={lowerProcessedDinners}
+                className="rounded-md bg-emerald-600 px-4 py-2 text-sm font-semibold text-white hover:bg-emerald-700"
+              >
+                Apply lower-processed dinner swaps
+              </button>
+            </div>
+            <div className="mt-4 grid gap-3 sm:grid-cols-3">
+              {mealSlots.map((slot) => {
+                const firstMeal = getMealTemplatesForSlot(slot)[0];
+
+                return (
+                  <button
+                    key={slot}
+                    type="button"
+                    onClick={() => repeatMealAcrossWeek(slot, firstMeal.id)}
+                    className="rounded-xl border border-slate-200 p-4 text-left hover:border-primary-200 hover:text-primary-700"
+                  >
+                    <span className="block text-xs font-semibold uppercase tracking-wide text-slate-500">
+                      Repeat {slot}
+                    </span>
+                    <span className="mt-1 block text-sm font-semibold">{firstMeal.name}</span>
+                  </button>
+                );
+              })}
+            </div>
+          </article>
+
           <div className="grid gap-6 xl:grid-cols-[0.95fr_1.05fr]">
             <article className="card p-6">
               <h3 className="text-lg font-semibold text-slate-900">Meal templates</h3>
@@ -238,13 +376,26 @@ const NutritionPlanner: React.FC = () => {
                         {meal.effort}
                       </span>
                     </div>
+                    <p className="mt-2 text-xs leading-relaxed text-primary-700">{meal.swapTip}</p>
                   </div>
                 ))}
               </div>
             </article>
 
             <article className="card p-6">
-              <h3 className="text-lg font-semibold text-slate-900">Grocery checklist</h3>
+              <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+                <div>
+                  <h3 className="text-lg font-semibold text-slate-900">Grocery checklist</h3>
+                  <p className="mt-1 text-sm text-slate-600">Copy groceries into your list app, then check off manually.</p>
+                </div>
+                <button
+                  type="button"
+                  onClick={() => copyText(buildGroceryAppOutput(groceryChecklist), 'Copied grocery-app handoff')}
+                  className="rounded-md border border-slate-200 px-3 py-2 text-xs font-semibold text-slate-700 hover:border-primary-200 hover:text-primary-700"
+                >
+                  Copy app handoff
+                </button>
+              </div>
               <div className="mt-4 space-y-5">
                 {groceryChecklist.map(({ category, items }) => (
                   <div key={category}>
@@ -264,6 +415,28 @@ const NutritionPlanner: React.FC = () => {
               </div>
             </article>
           </div>
+
+          <article className="card p-6">
+            <h3 className="text-lg font-semibold text-slate-900">Processed-food reduction guidance</h3>
+            <p className="mt-1 text-sm text-slate-600">
+              The goal is fewer default processed meals, not perfect avoidance. Keep convenience when it prevents skipped
+              meals.
+            </p>
+            <div className="mt-4 space-y-3">
+              {swapTips.length > 0 ? (
+                swapTips.map((swap) => (
+                  <div key={swap.mealName} className="rounded-lg border border-amber-100 bg-amber-50 p-4">
+                    <h4 className="text-sm font-semibold text-amber-950">{swap.mealName}</h4>
+                    <p className="mt-1 text-sm leading-relaxed text-amber-900">{swap.tip}</p>
+                  </div>
+                ))
+              ) : (
+                <div className="rounded-lg border border-emerald-100 bg-emerald-50 p-4 text-sm text-emerald-950">
+                  This plan is already using the lower-processed meal set.
+                </div>
+              )}
+            </div>
+          </article>
         </div>
       </div>
     </section>

--- a/src/data/nutrition.ts
+++ b/src/data/nutrition.ts
@@ -33,6 +33,7 @@ type MealTemplate = {
   processedLevel: 'low' | 'medium';
   repeatFriendly: boolean;
   why: string;
+  swapTip: string;
   ingredients: Ingredient[];
 };
 
@@ -46,6 +47,14 @@ type DayPlan = {
 type GrocerySection = {
   category: GroceryCategory;
   items: Ingredient[];
+};
+
+type WeekTemplate = {
+  id: string;
+  name: string;
+  description: string;
+  bestFor: string;
+  plan: DayPlan[];
 };
 
 const groceryCategories: GroceryCategory[] = ['Produce', 'Protein', 'Dairy', 'Pantry', 'Frozen', 'Bakery'];
@@ -82,6 +91,7 @@ const mealTemplates: MealTemplate[] = [
     processedLevel: 'low',
     repeatFriendly: true,
     why: 'Assemble once, repeat for low-friction mornings.',
+    swapTip: 'Keep oats, yogurt, and frozen berries stocked so breakfast does not depend on packaged bars.',
     ingredients: [
       { item: 'Rolled oats', quantity: 2, unit: 'cups', category: 'Pantry' },
       { item: 'Greek yogurt', quantity: 4, unit: 'cups', category: 'Dairy' },
@@ -97,6 +107,7 @@ const mealTemplates: MealTemplate[] = [
     processedLevel: 'low',
     repeatFriendly: true,
     why: 'Reliable savory breakfast with few ingredients.',
+    swapTip: 'Use pre-washed greens if prep energy is low; the meal still stays minimally processed.',
     ingredients: [
       { item: 'Eggs', quantity: 12, unit: 'count', category: 'Dairy' },
       { item: 'Spinach', quantity: 1, unit: 'bag', category: 'Produce' },
@@ -112,6 +123,7 @@ const mealTemplates: MealTemplate[] = [
     processedLevel: 'low',
     repeatFriendly: true,
     why: 'Batch-friendly lunch with easy portioning.',
+    swapTip: 'Batch the grain and protein once, then use jarred hummus instead of ultra-processed sauces.',
     ingredients: [
       { item: 'Chicken breast', quantity: 2, unit: 'lb', category: 'Protein' },
       { item: 'Brown rice', quantity: 2, unit: 'cups', category: 'Pantry' },
@@ -128,6 +140,7 @@ const mealTemplates: MealTemplate[] = [
     processedLevel: 'low',
     repeatFriendly: true,
     why: 'Low-cost leftovers that improve after a day.',
+    swapTip: 'Choose low-sodium broth and dry lentils to keep the convenience without leaning on frozen meals.',
     ingredients: [
       { item: 'Dry lentils', quantity: 2, unit: 'cups', category: 'Pantry' },
       { item: 'Carrots', quantity: 1, unit: 'bag', category: 'Produce' },
@@ -144,6 +157,7 @@ const mealTemplates: MealTemplate[] = [
     processedLevel: 'low',
     repeatFriendly: true,
     why: 'One pan, familiar flavors, and leftovers for lunch.',
+    swapTip: 'Use corn tortillas, salsa, and roasted vegetables to replace a takeout-style kit.',
     ingredients: [
       { item: 'Chicken thighs', quantity: 2, unit: 'lb', category: 'Protein' },
       { item: 'Bell peppers', quantity: 5, unit: 'count', category: 'Produce' },
@@ -160,6 +174,7 @@ const mealTemplates: MealTemplate[] = [
     processedLevel: 'low',
     repeatFriendly: false,
     why: 'Simple plate method dinner with minimal prep.',
+    swapTip: 'Buy frozen green beans or pre-washed potatoes when time is tight; avoid breaded frozen entrees.',
     ingredients: [
       { item: 'Salmon fillets', quantity: 4, unit: 'count', category: 'Protein' },
       { item: 'Baby potatoes', quantity: 2, unit: 'lb', category: 'Produce' },
@@ -175,6 +190,7 @@ const mealTemplates: MealTemplate[] = [
     processedLevel: 'medium',
     repeatFriendly: true,
     why: 'Uses canned staples intentionally for a lower-effort dinner.',
+    swapTip: 'Rinse canned beans, choose plain crushed tomatoes, and add extra vegetables before buying boxed chili kits.',
     ingredients: [
       { item: 'Ground turkey', quantity: 2, unit: 'lb', category: 'Protein' },
       { item: 'Canned beans', quantity: 4, unit: 'cans', category: 'Pantry' },
@@ -193,6 +209,50 @@ const defaultWeeklyPlan: DayPlan[] = [
   { day: 'Fri', breakfast: 'eggs-toast', lunch: 'grain-bowls', dinner: 'turkey-chili' },
   { day: 'Sat', breakfast: 'oats', lunch: 'lentil-soup', dinner: 'salmon-potatoes' },
   { day: 'Sun', breakfast: 'eggs-toast', lunch: 'grain-bowls', dinner: 'sheet-pan' },
+];
+
+const batchCookWeeklyPlan: DayPlan[] = [
+  { day: 'Mon', breakfast: 'oats', lunch: 'grain-bowls', dinner: 'sheet-pan' },
+  { day: 'Tue', breakfast: 'oats', lunch: 'grain-bowls', dinner: 'sheet-pan' },
+  { day: 'Wed', breakfast: 'oats', lunch: 'lentil-soup', dinner: 'turkey-chili' },
+  { day: 'Thu', breakfast: 'eggs-toast', lunch: 'lentil-soup', dinner: 'turkey-chili' },
+  { day: 'Fri', breakfast: 'eggs-toast', lunch: 'grain-bowls', dinner: 'sheet-pan' },
+  { day: 'Sat', breakfast: 'oats', lunch: 'lentil-soup', dinner: 'salmon-potatoes' },
+  { day: 'Sun', breakfast: 'eggs-toast', lunch: 'lentil-soup', dinner: 'salmon-potatoes' },
+];
+
+const lowDecisionWeeklyPlan: DayPlan[] = [
+  { day: 'Mon', breakfast: 'oats', lunch: 'grain-bowls', dinner: 'sheet-pan' },
+  { day: 'Tue', breakfast: 'oats', lunch: 'grain-bowls', dinner: 'sheet-pan' },
+  { day: 'Wed', breakfast: 'oats', lunch: 'grain-bowls', dinner: 'turkey-chili' },
+  { day: 'Thu', breakfast: 'oats', lunch: 'grain-bowls', dinner: 'turkey-chili' },
+  { day: 'Fri', breakfast: 'oats', lunch: 'lentil-soup', dinner: 'sheet-pan' },
+  { day: 'Sat', breakfast: 'eggs-toast', lunch: 'lentil-soup', dinner: 'salmon-potatoes' },
+  { day: 'Sun', breakfast: 'eggs-toast', lunch: 'lentil-soup', dinner: 'sheet-pan' },
+];
+
+const weekTemplates: WeekTemplate[] = [
+  {
+    id: 'balanced-repeat',
+    name: 'Balanced repeat week',
+    description: 'The default plan: familiar meals, a few repeats, and one medium-processed safety valve.',
+    bestFor: 'Starting from scratch',
+    plan: defaultWeeklyPlan,
+  },
+  {
+    id: 'batch-cook',
+    name: 'Batch-cook week',
+    description: 'Repeats lunches and dinners in pairs so prep can happen once and carry multiple days.',
+    bestFor: 'Lower weekday effort',
+    plan: batchCookWeeklyPlan,
+  },
+  {
+    id: 'low-decision',
+    name: 'Low-decision week',
+    description: 'Repeats breakfast and lunch heavily, leaving fewer choices for busy evenings.',
+    bestFor: 'Hard planning weeks',
+    plan: lowDecisionWeeklyPlan,
+  },
 ];
 
 const getMealTemplate = (id: string) => mealTemplates.find((meal) => meal.id === id) ?? mealTemplates[0];
@@ -235,8 +295,8 @@ const getLowerProcessedMealPercent = (plan: DayPlan[]) => {
 
 const formatQuantity = (value: number) => (Number.isInteger(value) ? String(value) : value.toFixed(1));
 
-const buildShareOutput = (plan: DayPlan[], groceryChecklist: GrocerySection[]) => {
-  const meals = plan
+const buildMealPlanOutput = (plan: DayPlan[]) =>
+  plan
     .map((day) => {
       const breakfast = getMealTemplate(day.breakfast).name;
       const lunch = getMealTemplate(day.lunch).name;
@@ -246,7 +306,8 @@ const buildShareOutput = (plan: DayPlan[], groceryChecklist: GrocerySection[]) =
     })
     .join('\n');
 
-  const groceries = groceryChecklist
+const buildGroceryOutput = (groceryChecklist: GrocerySection[]) =>
+  groceryChecklist
     .map(({ category, items }) => {
       if (items.length === 0) {
         return '';
@@ -258,19 +319,95 @@ const buildShareOutput = (plan: DayPlan[], groceryChecklist: GrocerySection[]) =
     .filter(Boolean)
     .join('\n\n');
 
+const getProcessedSwapTips = (plan: DayPlan[]) =>
+  Array.from(
+    new Map(
+      getPlannedMeals(plan)
+        .filter((meal) => meal.processedLevel === 'medium')
+        .map((meal) => [meal.id, { mealName: meal.name, tip: meal.swapTip }]),
+    ).values(),
+  );
+
+const getPlanningSummary = (plan: DayPlan[]) => {
+  const plannedMeals = getPlannedMeals(plan);
+  const uniqueMeals = new Set(plannedMeals.map((meal) => meal.id)).size;
+  const repeatFriendlyMeals = plannedMeals.filter((meal) => meal.repeatFriendly).length;
+  const tenMinuteMeals = plannedMeals.filter((meal) => meal.effort === '10 min').length;
+
+  return {
+    uniqueMeals,
+    repeatFriendlyMeals,
+    tenMinuteMeals,
+  };
+};
+
+const buildShareOutput = (plan: DayPlan[], groceryChecklist: GrocerySection[]) => {
+  const meals = buildMealPlanOutput(plan);
+  const groceries = buildGroceryOutput(groceryChecklist);
+
   return `Fitness Assistant weekly nutrition plan\n\nMeal plan\n${meals}\n\nGrocery checklist\n${groceries}`;
 };
 
+const cloneWeekPlan = (plan: DayPlan[]) => plan.map((day) => ({ ...day }));
+
+const getWeekTemplate = (id: string) => weekTemplates.find((template) => template.id === id) ?? weekTemplates[0];
+
+const buildTemplatePlan = (id: string) => cloneWeekPlan(getWeekTemplate(id).plan);
+
+const buildRepeatMealPlan = (mealId: string, slot: MealSlot, currentPlan: DayPlan[]) =>
+  currentPlan.map((day) => ({ ...day, [slot]: mealId }));
+
+const buildLowerProcessedPlan = (currentPlan: DayPlan[]) =>
+  currentPlan.map((day) => ({
+    ...day,
+    dinner: getMealTemplate(day.dinner).processedLevel === 'medium' ? 'sheet-pan' : day.dinner,
+  }));
+
+const getWeekTemplateMatch = (plan: DayPlan[]) => {
+  const signature = JSON.stringify(plan);
+  return weekTemplates.find((template) => JSON.stringify(template.plan) === signature);
+};
+
+const buildGroceryAppOutput = (groceryChecklist: GrocerySection[]) =>
+  groceryChecklist
+    .flatMap(({ items }) => items.map((item) => `${item.item} - ${formatQuantity(item.quantity)} ${item.unit}`))
+    .join('\n');
+
+const buildMealTemplateOutput = (plan: DayPlan[]) => {
+  const meals = plan
+    .map((day) => {
+      const breakfast = getMealTemplate(day.breakfast).name;
+      const lunch = getMealTemplate(day.lunch).name;
+      const dinner = getMealTemplate(day.dinner).name;
+
+      return `${day.day}: Breakfast - ${breakfast}; Lunch - ${lunch}; Dinner - ${dinner}`;
+    })
+    .join('\n');
+
+  return `Reusable meal template\n${meals}`;
+};
+
 export {
+  buildGroceryAppOutput,
   buildGroceryChecklist,
+  buildGroceryOutput,
+  buildLowerProcessedPlan,
+  buildMealPlanOutput,
+  buildMealTemplateOutput,
+  buildRepeatMealPlan,
   buildShareOutput,
+  buildTemplatePlan,
   defaultHousehold,
   defaultWeeklyPlan,
   formatQuantity,
   getLowerProcessedMealPercent,
   getMealTemplate,
   getMealTemplatesForSlot,
+  getPlanningSummary,
+  getProcessedSwapTips,
+  getWeekTemplateMatch,
   mealTemplates,
+  weekTemplates,
 };
 
 export type {
@@ -283,4 +420,5 @@ export type {
   MealTemplate,
   MemberProfile,
   PreferenceLevel,
+  WeekTemplate,
 };

--- a/tests/e2e/nutrition-planner.spec.ts
+++ b/tests/e2e/nutrition-planner.spec.ts
@@ -7,19 +7,18 @@ test.describe('nutrition planner', () => {
   });
 
   test('renders the household meal planner and grocery checklist', async ({ page }) => {
-    const groceryChecklist = page.getByRole('heading', { name: 'Grocery checklist' }).locator('..');
-
     await expect(page.getByRole('heading', { name: 'Household profile' })).toBeVisible();
     await expect(page.getByRole('heading', { name: 'Weekly meal plan' })).toBeVisible();
+    await expect(page.getByRole('button', { name: /Low-decision week/ })).toBeVisible();
+    await expect(page.getByRole('heading', { name: 'Low-friction planning actions' })).toBeVisible();
     await expect(page.getByRole('heading', { name: 'Grocery checklist' })).toBeVisible();
-    await expect(groceryChecklist.getByText('Chicken breast', { exact: true })).toBeVisible();
-    await expect(groceryChecklist.getByText('Bell peppers', { exact: true })).toBeVisible();
+    await expect(page.getByRole('heading', { name: 'Processed-food reduction guidance' })).toBeVisible();
+    await expect(page.getByText('Chicken breast', { exact: true })).toBeVisible();
+    await expect(page.getByText('Bell peppers', { exact: true })).toBeVisible();
     await expect(page.getByText('90% low processed')).toBeVisible();
   });
 
   test('allows member profile editing and meal changes', async ({ page }) => {
-    const groceryChecklist = page.getByRole('heading', { name: 'Grocery checklist' }).locator('..');
-
     await page.getByLabel('Member name').first().fill('Member One');
     await page.getByLabel('Preference').first().fill('Simple high-protein meals');
     await page.getByLabel('Convenience need').first().selectOption('high');
@@ -30,8 +29,8 @@ test.describe('nutrition planner', () => {
 
     await page.getByRole('row', { name: /Wed/ }).getByRole('combobox').nth(2).selectOption('turkey-chili');
 
-    await expect(groceryChecklist.getByText('Ground turkey', { exact: true })).toBeVisible();
-    await expect(groceryChecklist.getByText('Canned beans', { exact: true })).toBeVisible();
+    await expect(page.getByText('Ground turkey', { exact: true })).toBeVisible();
+    await expect(page.getByText('Canned beans', { exact: true })).toBeVisible();
   });
 
   test('keeps share output in sync with the selected plan', async ({ page }) => {
@@ -47,13 +46,43 @@ test.describe('nutrition planner', () => {
     await expect(shareOutput).toContainText('Ground turkey');
   });
 
+  test('applies reusable week templates and low-friction actions', async ({ page }) => {
+    await page.getByRole('button', { name: /Low-decision week/ }).click();
+
+    await expect(page.getByText('Current template: Low-decision week.')).toBeVisible();
+    await expect(page.getByText(/unique meals this week/)).toBeVisible();
+
+    await page.getByRole('button', { name: /Apply lower-processed dinner swaps/ }).click();
+
+    await expect(page.getByText('100% low processed')).toBeVisible();
+    await expect(page.getByText('This plan is already using the lower-processed meal set.')).toBeVisible();
+
+    await page.getByRole('button', { name: /Repeat lunch/ }).click();
+
+    await expect(page.getByText('lunch repeated across the week')).toBeVisible();
+  });
+
+  test('supports grocery-only and reusable template share formats', async ({ page }) => {
+    const shareOutput = page.getByRole('textbox').last();
+
+    await page.getByLabel('Output format').selectOption('Groceries only');
+
+    await expect(shareOutput).toContainText('Chicken breast -');
+    await expect(shareOutput).not.toContainText('Meal plan');
+
+    await page.getByLabel('Output format').selectOption('Meal template');
+
+    await expect(shareOutput).toContainText('Reusable meal template');
+    await expect(shareOutput).toContainText('Mon: Breakfast - Protein overnight oats');
+  });
+
   test('copies the share output for grocery app handoff', async ({ browserName, context, page }) => {
     test.skip(browserName !== 'chromium', 'clipboard permission is only configured for Chromium CI');
 
     await context.grantPermissions(['clipboard-read', 'clipboard-write']);
-    await page.getByRole('button', { name: 'Copy grocery handoff' }).click();
+    await page.getByRole('button', { name: 'Copy selected output' }).click();
 
-    await expect(page.getByText('Copied plan and grocery list')).toBeVisible();
+    await expect(page.getByText('Copied full plan')).toBeVisible();
     await expect(page.evaluate(() => navigator.clipboard.readText())).resolves.toContain('Grocery checklist');
   });
 });


### PR DESCRIPTION
## Summary
- add reusable week templates for balanced, batch-cook, and low-decision planning
- add low-friction repeat actions and lower-processed dinner swaps
- add share modes for full plan, grocery-only handoff, and reusable meal templates
- document the updated MVP state and expand Playwright coverage

## Validation
- npm run lint
- npm run build
- npm run test:e2e

Closes #5
Closes #6
Closes #7
Closes #8