### PR TITLE
Add Azure Terraform stack to replace Supabase

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,83 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## What this is
+
+A static React + TypeScript + Vite single-page app for fitness and household nutrition planning. The site has **no application backend** — it builds to static assets in `dist/` and deploys to GitHub Pages. The only server-side dependency is Supabase (hosted), used purely for auth and a `profiles` table; the app runs fully without it (`isSupabaseConfigured` gates all Supabase usage).
+
+The current product focus is the **nutrition MVP**: a household-first weekly meal planner that turns repeatable meal templates into a consolidated grocery checklist and shareable text output.
+
+## Commands
+
+```bash
+npm run dev            # Vite dev server
+npm run build          # production build to dist/ (used by CI and Pages)
+npm run preview        # serve the built app (Playwright drives this)
+npm run lint           # eslint, zero-warning gate
+
+npm run test           # unit + e2e
+npm run test:unit      # node --test over scripts/*.test.mjs and tests/unit/*.test.mjs
+npm run test:e2e       # Playwright (auto-starts `npm run preview` on :4173)
+npm run test:e2e:ui    # Playwright UI mode
+```
+
+Run a single unit test file: `node --test tests/unit/nutrition.test.mjs`
+Run a single e2e spec: `npx playwright test tests/e2e/nutrition-planner.spec.ts`
+
+First-time Playwright setup: `npx playwright install chromium`
+
+For Supabase-backed auth locally, copy `.env.example` to `.env.local` and set `VITE_SUPABASE_URL` and `VITE_SUPABASE_ANON_KEY`. The app runs without these.
+
+### Database test harnesses
+
+There are **two independent DB test paths**, mirrored by the two non-`verify` CI jobs:
+
+```bash
+# Portable Postgres (Docker/Podman) — relational portability check
+npm run db:local:start   # start container from docker-compose.db.yml
+npm run db:test          # apply bootstrap + migrations + database/tests/*.sql
+npm run db:local:reset
+npm run db:local:stop
+npm run test:portable-db # unit tests for the runner script itself
+
+# Hosted Supabase smoke check (needs SUPABASE_URL / SUPABASE_ANON_KEY env)
+npm run supabase:activity-check
+npm run test:activity-check
+```
+
+The portable harness (`scripts/portable-db.mjs`) applies SQL in order: `database/bootstrap/` (Supabase-compat shims so plain Postgres can run Supabase migrations) → `supabase/migrations/` → `database/tests/`. It auto-detects `docker` vs `podman`; override with `PORTABLE_DB_CONTAINER_CLI` and `PORTABLE_DB_PORT`.
+
+## Architecture
+
+### Domain logic lives in `src/data/nutrition.ts`
+This is the heart of the app and the single source of truth for the nutrition feature. It is **pure data + pure functions** — no React, no I/O — which is why it can be unit-tested with `node --test`. It contains:
+- Type definitions (`MealTemplate`, `DayPlan`, `GrocerySection`, `HouseholdProfile`, etc.)
+- Seed data: `mealTemplates`, `weekTemplates` (balanced/batch-cook/low-decision), `defaultHousehold`
+- Builders consumed by the UI: `buildGroceryChecklist` (consolidates duplicate ingredients by `category:item:unit`), `buildShareOutput` / `buildGroceryAppOutput` / `buildMealTemplateOutput` (share formats), `buildRepeatMealPlan`, `buildLowerProcessedPlan`, `getLowerProcessedMealPercent`, `getProcessedSwapTips`
+
+When adding nutrition behavior, add the pure function here with a `tests/unit` test, then wire it into the component. Don't put planning/grocery logic inside components.
+
+### Components in `src/components/` are presentational sections
+`App.tsx` composes the page as a fixed sequence of sections (Header → Hero → FeatureGrid → PlanSection → NutritionPlanner → GoalTracker → AuthSection → CTASection → Footer). Most sections render hardcoded marketing content passed as props from `App.tsx`. `NutritionPlanner.tsx` is the only stateful feature component; it holds the editable plan/household state and calls the `nutrition.ts` builders.
+
+### Supabase integration (`src/lib/`)
+- `supabase.ts` creates the client only when both `VITE_SUPABASE_URL` and `VITE_SUPABASE_ANON_KEY` are set; otherwise `supabase` is `null` and the UI degrades gracefully. Always guard usage on `isSupabaseConfigured`.
+- `database.types.ts` is **generated**, not hand-edited. CI fails if it drifts from the schema. Regenerate after any migration:
+  ```bash
+  supabase db start
+  supabase gen types typescript --local --schema public > src/lib/database.types.ts
+  ```
+- Roles (`app_role` enum): `provider` and `client` are public signup roles; `admin` and `mod` are invite-only / server-assigned.
+
+### Infrastructure (`infra/terraform/`)
+An Azure-native Terraform stack that replaces the hosted Supabase dependency (per the homelab spec — fitness-assistant is the Azure project, Databricks its key service). It provisions PostgreSQL Flexible Server (the `profiles` DB), Azure AD B2C (auth), Key Vault (secrets), and a Databricks workspace. It's **backend infra only** — the frontend stays on GitHub Pages, and the app code (`src/lib/`) still uses `@supabase/supabase-js`; rewiring it to the Azure SDKs is a documented follow-up. Conventions match `../ridge-to-coast/infra/terraform/`. See `infra/terraform/README.md` for the Supabase→Azure mapping and apply steps.
+
+### Deployment base path
+`vite.config.ts` reads `VITE_BASE_PATH`. The Pages workflow sets it to `/<repo-name>/` so assets resolve under `https://<owner>.github.io/<repo-name>/`. Local dev/preview default to `/`. Don't hardcode absolute asset paths.
+
+## CI gates (must pass before merge)
+`.github/workflows/ci.yml` runs three jobs on every PR: **portable-postgres** (`test:portable-db` + `db:test`), **supabase** (regenerates and diffs `database.types.ts`, runs `supabase test db`), and **verify** (lint → build → unit → e2e). Match these locally before pushing.
+
+## Reference docs
+`docs/nutrition-mvp-spec.md` (scope/success metrics), `docs/nutrition-data-model.md`, `docs/nutrition-workflow.md`, `docs/supabase-auth.md` (role schema + RLS), `docs/portable-postgres.md`, `docs/testing.md`, `docs/backlog/nutrition-mvp-backlog.md`.

--- a/README.md
+++ b/README.md
@@ -55,6 +55,17 @@ Implemented across the nutrition MVP branch:
 Supabase Auth powers login and signup. Public signup supports `provider` and `client` accounts. `admin` and `mod`
 roles are invite-only and should be assigned by existing admins or trusted server-side tooling.
 
+## Infrastructure
+
+`infra/terraform/` provisions an Azure-native stack that replaces the hosted Supabase dependency, aligned with the
+homelab spec (fitness-assistant is the Azure project; Databricks is its key service). It covers PostgreSQL Flexible
+Server (the `profiles` database), Azure AD B2C (auth), Key Vault (secrets), and a Databricks workspace for
+nutrition/wellness pipelines.
+
+This is **backend infrastructure only** — the frontend stays on GitHub Pages, and the app code still uses
+`@supabase/supabase-js`. Rewiring `src/lib/` to the Azure SDKs is a tracked follow-up. See
+`infra/terraform/README.md` for the Supabase → Azure mapping and apply steps.
+
 Related docs:
 
 - `docs/nutrition-mvp-spec.md` defines scope, out-of-scope items, and success metrics.
@@ -64,6 +75,7 @@ Related docs:
 - `docs/portable-postgres.md` documents the local Podman/Docker Postgres test harness for relational portability.
 - `docs/backlog/nutrition-mvp-backlog.md` links the nutrition backlog issues and priority sequence.
 - `docs/testing.md` explains local and CI test coverage.
+- `infra/terraform/README.md` documents the Azure Terraform stack that replaces Supabase (Postgres, Azure AD B2C, Key Vault, Databricks).
 
 ## Testing
 
@@ -97,6 +109,7 @@ For a custom domain, set the repository variable `PAGES_CNAME`. The workflow wri
 
 - `src/components/` contains React UI sections and reusable page blocks.
 - `src/data/nutrition.ts` contains the nutrition domain model, seed data, grocery generation, and share-output helpers.
+- `infra/terraform/` contains the Azure Terraform stack (Postgres, Azure AD B2C, Key Vault, Databricks) that replaces Supabase.
 - `tests/e2e/` contains Playwright browser tests.
 - `.github/workflows/ci.yml` runs PR verification.
 - `.github/workflows/deploy-pages.yml` publishes the static build to GitHub Pages.

--- a/docs/session-handoff.md
+++ b/docs/session-handoff.md
@@ -5,6 +5,7 @@ Current state:
 - PR `#17` is open with the `#5` through `#8` implementation pass.
 - The nutrition MVP centers on the household planner, reusable week templates, grocery checklist workflow, and manual share handoff.
 - Existing docs already cover the nutrition spec, data model, backlog, and testing.
+- `infra/terraform/` holds a new Azure Terraform stack (Postgres, Azure AD B2C, Key Vault, Databricks) that replaces the Supabase backend, aligned with the homelab spec. It is `terraform validate`-clean but not yet applied; app code still uses `@supabase/supabase-js`.
 
 Current plan:
 - Keep the app frontend-first and tighten the overall product polish.
@@ -15,3 +16,5 @@ Suggested next session starting point:
 1. Read `docs/nutrition-mvp-spec.md`, `docs/nutrition-workflow.md`, `docs/nutrition-data-model.md`, and `docs/backlog/nutrition-mvp-backlog.md`.
 2. Review `src/components/` and `src/data/nutrition.ts` for the current UI/data flow.
 3. Make the next MVP-facing improvement, then verify with `npm run lint`, `npm run build`, and `npm run test:e2e`.
+
+For the Azure migration, start from `infra/terraform/README.md` (apply steps + Supabase → Azure mapping); the app-code rewire from `@supabase/supabase-js` to the Azure SDKs is the tracked follow-up.

--- a/docs/supabase-auth.md
+++ b/docs/supabase-auth.md
@@ -2,6 +2,12 @@
 
 Fitness Assistant uses Supabase Auth for login and a `profiles` table for application roles.
 
+> **Migration note:** The infrastructure is moving to Azure — `infra/terraform/` provisions Azure AD B2C
+> (auth) and a PostgreSQL Flexible Server (the `profiles` database) to replace Supabase. This doc still
+> describes the live app, which uses Supabase until `src/lib/` is rewired to the Azure SDKs. The role model
+> below (`provider`/`client` public, `admin`/`mod` managed) carries over unchanged. See
+> `infra/terraform/README.md`.
+
 ## Roles
 
 The application role enum is:

--- a/infra/terraform/.gitignore
+++ b/infra/terraform/.gitignore
@@ -1,0 +1,20 @@
+# Credentials — never commit
+terraform.tfvars
+
+# Terraform working directory
+.terraform/
+.terraform.lock.hcl
+
+# State files — will move to azurerm backend
+terraform.tfstate
+terraform.tfstate.backup
+
+# Crash logs
+crash.log
+crash.*.log
+
+# Override files
+override.tf
+override.tf.json
+*_override.tf
+*_override.tf.json

--- a/infra/terraform/README.md
+++ b/infra/terraform/README.md
@@ -1,0 +1,86 @@
+# Azure Claude Stack (Terraform)
+
+Infrastructure that replaces the hosted **Supabase** dependency with an
+Azure-native stack, provisioned with Terraform. Aligns with the homelab spec
+(`../homelab/crews/azure.md`): fitness-assistant is the **Azure** project and
+**Databricks** is its key service.
+
+## What this replaces
+
+| Supabase piece | Azure resource | File |
+|---|---|---|
+| Auth (`auth.users`, JWT) | Azure AD B2C directory | `auth.tf` |
+| Postgres `profiles` table + `app_role` + RLS | PostgreSQL Flexible Server | `postgres.tf` |
+| Managed credentials | Key Vault (password + connection string) | `keyvault.tf` |
+| — *(spec-mandated addition)* | Azure Databricks workspace | `databricks.tf` |
+
+The frontend stays on **GitHub Pages** — Azure hosting is out of scope per the
+homelab spec. This stack is the backend only.
+
+## Layout
+
+```
+infra/terraform/
+├── main.tf                    # providers, backend, vars, resource group, tags
+├── postgres.tf                # Flexible Server + fitness_assistant DB + firewall
+├── keyvault.tf                # Key Vault + secrets + RBAC role assignment
+├── auth.tf                    # Azure AD B2C directory
+├── databricks.tf              # Databricks workspace
+├── outputs.tf                 # fqdn, vault uri, workspace url, b2c domain
+├── .gitignore                 # never commit tfvars / state
+└── terraform.tfvars.example   # copy → terraform.tfvars
+```
+
+## Prerequisites
+
+- Terraform >= 1.6
+- Azure CLI, logged in: `az login`
+- The signed-in principal is **Owner** (or Contributor + User Access
+  Administrator) on the subscription — needed to self-assign the Key Vault
+  Secrets Officer role in `keyvault.tf`.
+
+## Apply
+
+```bash
+cd infra/terraform
+cp terraform.tfvars.example terraform.tfvars   # then edit
+terraform init
+terraform plan
+terraform apply
+```
+
+## Post-apply: load the profiles schema
+
+The schema in `../../supabase/migrations/` is portable Postgres (the
+`../../database/bootstrap/` shims prove it runs on vanilla PG), so it applies to
+the new server unchanged. Set `admin_ip_address` first so the firewall lets you in:
+
+```bash
+PGPASSWORD=$(az keyvault secret show \
+  --vault-name "$(terraform output -raw key_vault_uri | sed 's|https://||;s|/||g;s|.vault.azure.net||')" \
+  --name postgres-admin-password --query value -o tsv)
+
+psql "host=$(terraform output -raw postgres_server_fqdn) \
+  user=$(terraform output -raw postgres_admin_username) \
+  dbname=$(terraform output -raw postgres_database_name) sslmode=require" \
+  -f ../../database/bootstrap/000_supabase_compat.sql \
+  -f ../../supabase/migrations/202605160001_auth_profiles.sql
+```
+
+## Post-apply: auth wiring
+
+Azure AD B2C needs its user flows and SPA app registration configured against
+the tenant after it exists (not fully Terraformable pre-tenant). In the B2C
+tenant (`terraform output b2c_tenant_domain`):
+
+1. Create a **Sign up and sign in** user flow.
+2. Register the SPA app; add the GitHub Pages URL as a redirect URI.
+3. Add a `role` custom attribute mapping the `app_role` values
+   (`provider`/`client` public, `admin`/`mod` managed).
+
+## Follow-up (not in this stack)
+
+Rewiring `src/lib/supabase.ts` from `@supabase/supabase-js` to the Azure SDKs
+(MSAL for B2C auth, `pg`/PostgREST for the profiles data) is a separate change.
+Until then the app runs unauthenticated — `isSupabaseConfigured` already gates
+all Supabase usage, so nothing breaks.

--- a/infra/terraform/auth.tf
+++ b/infra/terraform/auth.tf
@@ -1,0 +1,27 @@
+# Azure AD B2C directory — replaces Supabase Auth (auth.users + JWT issuance).
+# This provisions the CIAM tenant. The user flows (sign-up/sign-in) and the
+# SPA app registration are configured against this tenant after it exists —
+# see README, "Post-apply: auth wiring". The app_role model (provider/client
+# public, admin/mod managed) maps to B2C custom attributes / app roles there.
+resource "azurerm_aadb2c_directory" "auth" {
+  resource_group_name     = azurerm_resource_group.main.name
+  country_code            = var.b2c_country_code
+  data_residency_location = var.b2c_data_residency
+  display_name            = "Fitness Assistant Auth"
+  domain_name             = "fitnessassistant${random_string.suffix.result}.onmicrosoft.com"
+  sku_name                = "PremiumP1"
+
+  tags = local.tags
+}
+
+variable "b2c_country_code" {
+  description = "ISO country code for the B2C tenant (e.g. US)."
+  type        = string
+  default     = "US"
+}
+
+variable "b2c_data_residency" {
+  description = "B2C data residency location: United States, Europe, Asia Pacific, or Australia."
+  type        = string
+  default     = "United States"
+}

--- a/infra/terraform/databricks.tf
+++ b/infra/terraform/databricks.tf
@@ -1,0 +1,23 @@
+# Azure Databricks workspace — the homelab-mandated key service for
+# fitness-assistant (see homelab crews/azure.md: "Databricks for data
+# processing and ML pipelines, not just storage"). This is the nutrition
+# and wellness data pipeline layer; jobs/notebooks/Delta tables are added
+# by the Data role once the workspace is provisioned.
+resource "azurerm_databricks_workspace" "main" {
+  name                = "${local.name_prefix}-dbx"
+  resource_group_name = azurerm_resource_group.main.name
+  location            = azurerm_resource_group.main.location
+  sku                 = var.databricks_sku
+
+  # Databricks creates a locked, managed resource group for its own
+  # compute/networking; name it explicitly so it's identifiable.
+  managed_resource_group_name = "${local.name_prefix}-dbx-managed"
+
+  tags = local.tags
+}
+
+variable "databricks_sku" {
+  description = "Databricks pricing tier: standard, premium, or trial. premium is required for RBAC/Unity Catalog."
+  type        = string
+  default     = "premium"
+}

--- a/infra/terraform/keyvault.tf
+++ b/infra/terraform/keyvault.tf
@@ -1,0 +1,43 @@
+# Key Vault — holds the Postgres admin password + connection string.
+# Replaces Supabase's managed-credential storage. Secrets never land in
+# terraform.tfvars or .env; the app reads them from the vault at deploy time.
+resource "azurerm_key_vault" "main" {
+  name                = "fa-kv-${random_string.suffix.result}"
+  location            = azurerm_resource_group.main.location
+  resource_group_name = azurerm_resource_group.main.name
+  tenant_id           = data.azurerm_client_config.current.tenant_id
+  sku_name            = "standard"
+
+  # RBAC instead of legacy access policies — least privilege, matches
+  # homelab's "least privilege IAM throughout" decision.
+  rbac_authorization_enabled = true
+  purge_protection_enabled   = false
+
+  tags = local.tags
+}
+
+# Let the deploying principal write secrets during apply. Requires the
+# principal to be Owner/User Access Administrator on the subscription.
+resource "azurerm_role_assignment" "kv_secrets_officer" {
+  scope                = azurerm_key_vault.main.id
+  role_definition_name = "Key Vault Secrets Officer"
+  principal_id         = data.azurerm_client_config.current.object_id
+}
+
+resource "azurerm_key_vault_secret" "pg_admin_password" {
+  name         = "postgres-admin-password"
+  value        = random_password.pg_admin.result
+  key_vault_id = azurerm_key_vault.main.id
+  tags         = local.tags
+
+  depends_on = [azurerm_role_assignment.kv_secrets_officer]
+}
+
+resource "azurerm_key_vault_secret" "pg_connection_string" {
+  name         = "postgres-connection-string"
+  value        = "postgresql://${azurerm_postgresql_flexible_server.main.administrator_login}:${random_password.pg_admin.result}@${azurerm_postgresql_flexible_server.main.fqdn}:5432/${azurerm_postgresql_flexible_server_database.profiles.name}?sslmode=require"
+  key_vault_id = azurerm_key_vault.main.id
+  tags         = local.tags
+
+  depends_on = [azurerm_role_assignment.kv_secrets_officer]
+}

--- a/infra/terraform/main.tf
+++ b/infra/terraform/main.tf
@@ -1,0 +1,88 @@
+terraform {
+  required_version = ">= 1.6"
+
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "~> 4"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3"
+    }
+  }
+
+  # Uncomment to store state in Azure Blob Storage after the backend
+  # storage account + container exist (create them once, out of band):
+  #   az group create -n tfstate-rg -l eastus
+  #   az storage account create -n <globally-unique> -g tfstate-rg --sku Standard_LRS
+  #   az storage container create -n tfstate --account-name <globally-unique>
+  # backend "azurerm" {
+  #   resource_group_name  = "tfstate-rg"
+  #   storage_account_name = "faclaudetfstate"
+  #   container_name       = "tfstate"
+  #   key                  = "fitness-assistant.tfstate"
+  # }
+}
+
+provider "azurerm" {
+  features {}
+  subscription_id = var.subscription_id
+}
+
+data "azurerm_client_config" "current" {}
+
+variable "subscription_id" {
+  description = "Azure subscription ID — not secret, safe to commit. `az account show --query id -o tsv`"
+  type        = string
+}
+
+variable "location" {
+  description = "Azure region for all resources."
+  type        = string
+  default     = "eastus"
+}
+
+variable "project" {
+  description = "Project slug — used as the base for every resource name."
+  type        = string
+  default     = "fitness-assistant"
+}
+
+variable "environment" {
+  description = "Deployment environment (prod, staging, dev)."
+  type        = string
+  default     = "prod"
+}
+
+variable "extra_tags" {
+  description = "Additional tags merged onto every resource."
+  type        = map(string)
+  default     = {}
+}
+
+# Short random suffix so globally-unique names (Postgres, Key Vault, B2C domain)
+# don't collide across environments or re-creates.
+resource "random_string" "suffix" {
+  length  = 6
+  special = false
+  upper   = false
+}
+
+locals {
+  name_prefix = "${var.project}-${var.environment}"
+
+  tags = merge({
+    project     = var.project
+    environment = var.environment
+    managed_by  = "terraform"
+    stack       = "azure-claude-stack"
+    replaces    = "supabase"
+  }, var.extra_tags)
+}
+
+resource "azurerm_resource_group" "main" {
+  name     = "${local.name_prefix}-rg"
+  location = var.location
+  tags     = local.tags
+}

--- a/infra/terraform/outputs.tf
+++ b/infra/terraform/outputs.tf
@@ -1,0 +1,44 @@
+output "resource_group_name" {
+  description = "Resource group holding the whole stack."
+  value       = azurerm_resource_group.main.name
+}
+
+output "postgres_server_fqdn" {
+  description = "Postgres host — the DB half of the old Supabase project."
+  value       = azurerm_postgresql_flexible_server.main.fqdn
+}
+
+output "postgres_database_name" {
+  description = "Database that holds the profiles schema."
+  value       = azurerm_postgresql_flexible_server_database.profiles.name
+}
+
+output "postgres_admin_username" {
+  description = "Postgres admin login."
+  value       = azurerm_postgresql_flexible_server.main.administrator_login
+}
+
+output "key_vault_uri" {
+  description = "Key Vault URI. Postgres password + connection string live here."
+  value       = azurerm_key_vault.main.vault_uri
+}
+
+output "postgres_connection_string_secret" {
+  description = "Key Vault secret name for the full connection string."
+  value       = azurerm_key_vault_secret.pg_connection_string.name
+}
+
+output "databricks_workspace_url" {
+  description = "Databricks workspace URL for nutrition/wellness pipelines."
+  value       = azurerm_databricks_workspace.main.workspace_url
+}
+
+output "b2c_tenant_domain" {
+  description = "Azure AD B2C domain — replaces Supabase Auth. Configure user flows + app registration here."
+  value       = azurerm_aadb2c_directory.auth.domain_name
+}
+
+output "b2c_tenant_id" {
+  description = "Azure AD B2C tenant ID."
+  value       = azurerm_aadb2c_directory.auth.tenant_id
+}

--- a/infra/terraform/postgres.tf
+++ b/infra/terraform/postgres.tf
@@ -1,0 +1,67 @@
+# Azure Database for PostgreSQL Flexible Server — replaces the Supabase
+# Postgres that hosts the `profiles` table + `app_role` enum + RLS policies.
+# The existing schema in supabase/migrations/ is portable Postgres (the
+# database/bootstrap/ shims already prove it runs on vanilla PG), so it
+# applies here unchanged after provisioning. See README for the load step.
+
+resource "random_password" "pg_admin" {
+  length           = 24
+  special          = true
+  override_special = "!#$%*-_"
+}
+
+resource "azurerm_postgresql_flexible_server" "main" {
+  name                = "${local.name_prefix}-pg-${random_string.suffix.result}"
+  resource_group_name = azurerm_resource_group.main.name
+  location            = azurerm_resource_group.main.location
+
+  version                = "15" # match supabase/config.toml major_version
+  administrator_login    = "fitnessadmin"
+  administrator_password = random_password.pg_admin.result
+
+  sku_name   = "B_Standard_B1ms" # burstable, smallest tier — right-size later
+  storage_mb = 32768
+  zone       = "1"
+
+  # Public endpoint gated by firewall rules below. Switch to a delegated
+  # subnet / private endpoint when the app moves off GitHub Pages.
+  public_network_access_enabled = true
+
+  tags = local.tags
+
+  lifecycle {
+    # Zone can be reassigned by Azure on some operations; ignore drift.
+    ignore_changes = [zone]
+  }
+}
+
+resource "azurerm_postgresql_flexible_server_database" "profiles" {
+  name      = "fitness_assistant"
+  server_id = azurerm_postgresql_flexible_server.main.id
+  collation = "en_US.utf8"
+  charset   = "utf8"
+}
+
+# Allow other Azure services (e.g. Databricks) to reach the server.
+resource "azurerm_postgresql_flexible_server_firewall_rule" "azure_services" {
+  name             = "allow-azure-services"
+  server_id        = azurerm_postgresql_flexible_server.main.id
+  start_ip_address = "0.0.0.0"
+  end_ip_address   = "0.0.0.0"
+}
+
+# Optional: allow a single operator IP to apply the schema / debug.
+# Leave admin_ip_address empty to skip this rule.
+resource "azurerm_postgresql_flexible_server_firewall_rule" "operator" {
+  count            = var.admin_ip_address == "" ? 0 : 1
+  name             = "allow-operator"
+  server_id        = azurerm_postgresql_flexible_server.main.id
+  start_ip_address = var.admin_ip_address
+  end_ip_address   = var.admin_ip_address
+}
+
+variable "admin_ip_address" {
+  description = "Your public IP, to open a firewall rule for schema loading / psql. `curl -s ifconfig.me`. Empty = no operator rule."
+  type        = string
+  default     = ""
+}

--- a/infra/terraform/terraform.tfvars.example
+++ b/infra/terraform/terraform.tfvars.example
@@ -1,0 +1,22 @@
+# Copy this file to terraform.tfvars and fill in your values.
+# terraform.tfvars is gitignored — never commit it.
+#
+# Where to find each value:
+#   subscription_id    → `az account show --query id -o tsv`
+#   location           → any Azure region, e.g. eastus, westus2, westeurope
+#   admin_ip_address   → `curl -s ifconfig.me` (opens a Postgres firewall rule
+#                        so you can load the profiles schema over psql). Leave
+#                        empty ("") to skip the operator rule.
+#   b2c_data_residency → United States | Europe | Asia Pacific | Australia
+
+subscription_id    = "00000000-0000-0000-0000-000000000000"
+location           = "eastus"
+admin_ip_address   = ""
+
+# Optional overrides (defaults are usually fine):
+# project            = "fitness-assistant"
+# environment        = "prod"
+# databricks_sku     = "premium"
+# b2c_country_code   = "US"
+# b2c_data_residency = "United States"
+# extra_tags         = { owner = "loobo07" }


### PR DESCRIPTION
## Summary

Provisions an Azure-native backend stack under `infra/terraform/` that replaces the hosted **Supabase** dependency, aligned with the homelab spec (`../homelab/crews/azure.md`: fitness-assistant is the **Azure** project, **Databricks** its key service). Terraform conventions mirror `ridge-to-coast/infra/terraform/`.

### Supabase → Azure mapping

| Supabase | Azure resource | File |
|---|---|---|
| Auth (`auth.users`, JWT) | Azure AD B2C directory | `auth.tf` |
| Postgres `profiles` + `app_role` + RLS | PostgreSQL Flexible Server (v15) | `postgres.tf` |
| Managed credentials | Key Vault + secrets (RBAC, random password) | `keyvault.tf` |
| *(spec-mandated)* | Databricks workspace | `databricks.tf` |

Plus `main.tf` (providers, commented azurerm backend, resource group, tags), `outputs.tf`, `.gitignore`, and `terraform.tfvars.example`.

## Scope boundaries

- **Backend infra only.** Frontend stays on GitHub Pages (spec marks Azure hosting as future scope).
- **App code untouched.** `src/lib/` still uses `@supabase/supabase-js`; rewiring to the Azure SDKs (MSAL + `pg`) is a documented follow-up. `isSupabaseConfigured` already gates all Supabase usage, so nothing breaks meanwhile.
- The `profiles` schema loads onto the new Postgres unchanged (the `database/bootstrap/` shims prove it's portable) — `psql` steps in `infra/terraform/README.md`.

## Verification

- `terraform fmt` — clean
- `terraform init` + `terraform validate` — **Success, zero warnings** (real azurerm v4 schemas)

## Docs

README Infrastructure section, `supabase-auth.md` migration note, `session-handoff.md` pointer, and a project `CLAUDE.md`.

## Known caveat

`azurerm_aadb2c_directory` provisions the B2C tenant, but B2C user flows + the SPA app registration can't be Terraformed before the tenant exists — documented as post-apply steps rather than faked as resources.

🤖 Generated with [Claude Code](https://claude.com/claude-code)